### PR TITLE
Fix CI Lint hang (dead prettier-edgejs stub + eslint-plugin-prettier deadlock)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,7 @@ env:
 jobs:
   lint:
     name: Lint
+    timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/api/.prettierrc.cjs
+++ b/api/.prettierrc.cjs
@@ -2,7 +2,7 @@
 
 module.exports = {
   printWidth: 100,
-  plugins: ['prettier-edgejs'],
+  plugins: ['prettier-plugin-edgejs'],
   overrides: [
     {
       // Lol, JavaScript
@@ -41,7 +41,7 @@ module.exports = {
         quoteProps: 'consistent',
         bracketSpacing: true,
         arrowParens: 'always',
-        plugins: ['prettier-edgejs'],
+        plugins: ['prettier-plugin-edgejs'],
       },
     },
   ],

--- a/api/app/services/stripe_sync.ts
+++ b/api/app/services/stripe_sync.ts
@@ -3,7 +3,7 @@ import Account from '#models/account';
 import { stripe } from '#services/stripe';
 import type Stripe from 'stripe';
 
-export type STRIPE_SUB_CACHE =
+export type StripeSubCache =
   | {
       subscriptionId: string | null;
       status: Stripe.Subscription.Status;
@@ -77,14 +77,14 @@ export async function getOrCreateStripeCustomerIdForAccount(params: {
  */
 export async function syncStripeDataToAccountByCustomerId(
   customerId: string
-): Promise<STRIPE_SUB_CACHE | null> {
+): Promise<StripeSubCache | null> {
   const account = await Account.findBy('stripe_customer_id', customerId);
   if (!account) return null;
 
   return await syncStripeDataToAccount(account);
 }
 
-export async function syncStripeDataToAccount(account: Account): Promise<STRIPE_SUB_CACHE | null> {
+export async function syncStripeDataToAccount(account: Account): Promise<StripeSubCache | null> {
   const customerId = account.stripeCustomerId;
   if (!customerId) return null;
 
@@ -126,7 +126,7 @@ export async function syncStripeDataToAccount(account: Account): Promise<STRIPE_
         }
       : null;
 
-  const subData: STRIPE_SUB_CACHE = {
+  const subData: StripeSubCache = {
     subscriptionId: subscription.id,
     status: subscription.status,
     priceId,

--- a/api/eslint.config.js
+++ b/api/eslint.config.js
@@ -12,6 +12,14 @@ export default [
 
       // Filename conventions are silly
       '@unicorn/filename-case': 'off',
+
+      // Formatting is enforced separately (`pnpm format` + git diff in CI's
+      // Lint job). Running prettier per-file inside eslint is double work,
+      // and it deadlocks: eslint-plugin-prettier's synckit worker does
+      // `import prettier from 'prettier'`, which crashes on our
+      // source-built prettier fork (no default export) and leaves the
+      // main thread blocked on Atomics.wait forever.
+      'prettier/prettier': 'off',
     },
   },
 ];

--- a/api/package.json
+++ b/api/package.json
@@ -71,7 +71,7 @@
     "openapi3-ts": "^4.4.0",
     "playwright": "^1.50.1",
     "prettier": "github:jurgenwerk/prettier#glimmer-embed-style-wip",
-    "prettier-edgejs": "^0.2.34",
+    "prettier-plugin-edgejs": "^1.0.7",
     "typescript": "^5.7.3",
     "uuid": "^13.0.0"
   },

--- a/api/resources/views/components/header.edge
+++ b/api/resources/views/components/header.edge
@@ -19,7 +19,7 @@
 </header>
 <script>
   const header = document.querySelector("header");
-  
+
   function onScroll() {
     if (window.scrollY > 0) {
       header.classList.add("did-scroll");
@@ -27,9 +27,9 @@
       header.classList.remove("did-scroll");
     }
   }
-  
+
   onScroll();
-  
+
   window.addEventListener("scroll", onScroll, {
     passive: true
   });

--- a/api/resources/views/components/layout/app.edge
+++ b/api/resources/views/components/layout/app.edge
@@ -16,7 +16,7 @@
     @endif
     <link href="/css/app.css" rel="stylesheet" />
     <script src="https://cdn.jsdelivr.net/npm/canvas-confetti@1.9.3/dist/confetti.browser.min.js">
-      
+
     </script>
   </head>
 

--- a/api/resources/views/docs/scalar-ui.edge
+++ b/api/resources/views/docs/scalar-ui.edge
@@ -14,7 +14,7 @@
       id="api-reference"
       data-url="https://cdn.jsdelivr.net/npm/@scalar/galaxy/dist/latest.yaml"
       data-proxy-url="https://proxy.scalar.com">
-      
+
     </script>
 
     <!-- Optional: You can set a full configuration object like this: -->
@@ -44,12 +44,12 @@
         customCss: `.open-api-client-button { display: none !important; }`,
         hiddenClients: []
       };
-      
+
       document.getElementById("api-reference").dataset.configuration = JSON.stringify(configuration);
     </script>
 
     <script src="https://cdn.jsdelivr.net/npm/@scalar/api-reference">
-      
+
     </script>
   </body>
 </html>

--- a/api/resources/views/success.edge
+++ b/api/resources/views/success.edge
@@ -19,9 +19,9 @@
           y: .6
         }
       });
-      
+
       const button = document.querySelector(".short-url-with-copy button.copy-shortUrl");
-      
+
       if ("ClipboardItem" in globalThis) {
         button.addEventListener("click", () => setClipboard("{{ data.attributes.shortUrl }}"));
         async function setClipboard(text) {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,7 +29,7 @@ importers:
         version: 5.1.1(@adonisjs/core@6.19.3(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@vinejs/vine@4.2.0)(edge.js@6.4.0))
       '@adonisjs/auth':
         specifier: ^9.3.1
-        version: 9.5.1(p5grlqoizembbn45vzffxszpdq)
+        version: 9.5.1(6b2bd7ec29f2e3c48da0991ceb6f39c3)
       '@adonisjs/bouncer':
         specifier: ^3.1.5
         version: 3.1.6(@adonisjs/core@6.19.3(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@vinejs/vine@4.2.0)(edge.js@6.4.0))(edge.js@6.4.0)
@@ -166,9 +166,9 @@ importers:
       prettier:
         specifier: github:jurgenwerk/prettier#glimmer-embed-style-wip
         version: https://codeload.github.com/jurgenwerk/prettier/tar.gz/4ec1dd2669715bb9e4487366f330f7686fb5d159
-      prettier-edgejs:
-        specifier: ^0.2.34
-        version: 0.2.36
+      prettier-plugin-edgejs:
+        specifier: ^1.0.7
+        version: 1.0.7
       typescript:
         specifier: ^5.7.3
         version: 5.9.3
@@ -477,7 +477,7 @@ packages:
     version: 2.1.2
     peerDependencies:
       eslint: ^9.9.0
-      prettier: github:jurgenwerk/prettier#glimmer-embed-style-wip
+      prettier: ^3.3.3
 
   '@adonisjs/eslint-plugin@2.2.1':
     resolution: {integrity: sha512-FlMAjhWYOHpWtzQY8+VLtXHyHJ6ts15PCZ2xgSH7OcKsBiwQSEUPXH6nGiY0hlG09Li/Jqco4fEhmrf7KEi4jQ==}
@@ -1675,20 +1675,20 @@ packages:
   '@borewit/text-codec@0.2.1':
     resolution: {integrity: sha512-k7vvKPbf7J2fZ5klGRD9AeKfUvojuZIQ3BT5u7Jfv+puwXkUBUT5PVyMDfJZpy30CBDXGMgw7fguK/lpOMBvgw==}
 
-  '@chevrotain/cst-dts-gen@11.1.0':
-    resolution: {integrity: sha512-Sa/G9XD23V4StfHMeQNnXbFmj8CsYUBmf+L895/hKm0RFDhxAfHzV6e58NA8j5ninntT5yqMzBW8QEbYxLkNUw==}
+  '@chevrotain/cst-dts-gen@11.2.0':
+    resolution: {integrity: sha512-ssJFvn/UXhQQeICw3SR/fZPmYVj+JM2mP+Lx7bZ51cOeHaMWOKp3AUMuyM3QR82aFFXTfcAp67P5GpPjGmbZWQ==}
 
-  '@chevrotain/gast@11.1.0':
-    resolution: {integrity: sha512-0fyRYDFneUhbyV6k22R6bBY02+FasLqcxXYVt8z51IWTZ10l2Z2Lc0hiPTgm8MNRbYZnDbNv78b9zY5DoIJKjQ==}
+  '@chevrotain/gast@11.2.0':
+    resolution: {integrity: sha512-c+KoD6eSI1xjAZZoNUW+V0l13UEn+a4ShmUrjIKs1BeEWCji0Kwhmqn5FSx1K4BhWL7IQKlV7wLR4r8lLArORQ==}
 
-  '@chevrotain/regexp-to-ast@11.1.0':
-    resolution: {integrity: sha512-3rW046uSp36liIAc/5G6A6h3gGbDN1eONpmJQpybIb+G2kSz0BNRc9ziT4DYrCUUbgNLd6bNVROqN9r7ZaajYg==}
+  '@chevrotain/regexp-to-ast@11.2.0':
+    resolution: {integrity: sha512-lG73pBFqbXODTbXhdZwv0oyUaI+3Irm+uOv5/W79lI3g5hasYaJnVJOm3H2NkhA0Ef4XLBU4Scr7TJDJwgFkAw==}
 
-  '@chevrotain/types@11.1.0':
-    resolution: {integrity: sha512-GXni/dwJAkClMfwCtrbGU19RXQ9O76hFxq3sgy/zufXNj3ov6J/8FOWIXxJLhnKx7gzSweATmRccjlpmr5W2nA==}
+  '@chevrotain/types@11.2.0':
+    resolution: {integrity: sha512-vBMSj/lz/LqolbGQEHB0tlpW5BnljHVtp+kzjQfQU+5BtGMTuZCPVgaAjtKvQYXnHb/8i/02Kii00y0tsuwfsw==}
 
-  '@chevrotain/utils@11.1.0':
-    resolution: {integrity: sha512-DrS2yldzFnjmBV0O/kDngcFxWuqg2FdmUpaD6KyTmgIIE6lR53dq80R/Zz+o6LpUrXsLJk192kXuaeIPic4WVg==}
+  '@chevrotain/utils@11.2.0':
+    resolution: {integrity: sha512-+7whECg4yNWHottjvr2To2BRxL4XJVjIyyv5J4+bJ0iMOVU8j/8n1qPDLZS/90W/BObDR8VNL46lFbzY/Hosmw==}
 
   '@cnakazawa/watch@1.0.4':
     resolution: {integrity: sha512-v9kIhKwjeZThiWrLmj0y17CWoyddASLj9O2yvbZkbvw/N3rWOYy9zkV66ursAoVr0mV15bL8g0c4QZUE6cdDoQ==}
@@ -3992,8 +3992,8 @@ packages:
     resolution: {integrity: sha512-drVkSqfwA+TvuEhFipiR1OC9boEGZL5RrWvVsOthdcvQNXyCCuKkEiTOTXZ7qxSf/GLwq4GvzfrQD/Wz325hgw==}
     engines: {node: '>=16'}
 
-  chevrotain@11.1.0:
-    resolution: {integrity: sha512-BqwSf3RDQlHQ+EyWqTLDd23IwJ3clav6QyNQM4FNj0RF2/HfXESPjrApKkEstV5jbyJtUB8U4zrUFdLd2Cx1oA==}
+  chevrotain@11.2.0:
+    resolution: {integrity: sha512-mHCHTxM51nCklUw9RzRVc0DLjAh/SAUPM4k/zMInlTIo25ldWXOZoPt7XEIk/LwoT4lFVmJcu9g5MHtx371x3A==}
 
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
@@ -4712,8 +4712,8 @@ packages:
     resolution: {integrity: sha512-c19PeUKrADqu+XBr8wSKdjqW/L65xiEfBMh9nbTx6ieF3SV7Ajb3PdfvrYPuLnobgs/bwtem1+InYVFSaWPc1A==}
     engines: {node: '>=18.16.0'}
 
-  edgejs-parser@0.2.18:
-    resolution: {integrity: sha512-O1Xg3ISESg2bl8DqP5q3x1b88cqTSgLmEBqNhGH482JdAIexDY7gh7FA9Y5kHOFwRNsTLFoziwQou0lprJ1MYQ==}
+  edgejs-parser@0.2.19:
+    resolution: {integrity: sha512-KO9pF1JSd6dDL7+hJM1W7PbzdTV/siSCoYbN3Ej84csh4RUBd14NvE4uzm4LOiuph9w/j+YlcBkPyp0C5SOzrQ==}
 
   editions@1.3.4:
     resolution: {integrity: sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==}
@@ -5138,7 +5138,7 @@ packages:
       '@types/eslint': '>=8.0.0'
       eslint: '>=8.0.0'
       eslint-config-prettier: '>= 7.0.0 <10.0.0 || >=10.1.0'
-      prettier: github:jurgenwerk/prettier#glimmer-embed-style-wip
+      prettier: '>=3.0.0'
     peerDependenciesMeta:
       '@types/eslint':
         optional: true
@@ -6664,8 +6664,8 @@ packages:
     resolution: {integrity: sha512-XT9ewWAC43tiAV7xDAPflMkG0qOPn2QjHqlgX8FOqmWa/rxnyYDulF9T0F7tRy1u+TVTmK/M//6VIOye+2zDXg==}
     engines: {node: '>=20'}
 
-  lodash-es@4.17.21:
-    resolution: {integrity: sha512-mKnC+QJ9pWVzv+C4/U3rRsHapFfHvQFoFB92e52xeyGMcX6/OlIl78je1u8vePzYZSkkogMPJ2yjxxsb89cxyw==}
+  lodash-es@4.17.23:
+    resolution: {integrity: sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==}
 
   lodash._baseflatten@3.1.4:
     resolution: {integrity: sha512-fESngZd+X4k+GbTxdMutf8ohQa0s3sJEHIcwtu4/LsIQ2JTDzdRxDCMQjW+ezzwRitLmHnacVVmosCbxifefbw==}
@@ -7587,23 +7587,19 @@ packages:
     resolution: {integrity: sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==}
     engines: {node: '>= 0.8.0'}
 
-  prettier-edgejs@0.2.36:
-    resolution: {integrity: sha512-MDhy6uLAxFjnHh9o9uL40wLt4dNvPkQRmnA9JRcwQVad+bKcVSCvvGoZigRL1CQzKCSU17WC1maLTKtHCrAPxQ==}
-    deprecated: This package has been renamed to prettier-plugin-edgejs. Please install that instead.
-
   prettier-linter-helpers@1.0.1:
     resolution: {integrity: sha512-SxToR7P8Y2lWmv/kTzVLC1t/GDI2WGjMwNhLLE9qtH8Q13C+aEmuRlzDst4Up4s0Wc8sF2M+J57iB3cMLqftfg==}
     engines: {node: '>=6.0.0'}
 
-  prettier-plugin-edgejs@1.0.6:
-    resolution: {integrity: sha512-RZ3xPEiHfw6ca/YzfKmu6rSOviheC9THfGlqg7rs8srbr1RugJQ8k3KmjLHH1oXadQBzZeIeZ3d25Dhs+fe4UA==}
+  prettier-plugin-edgejs@1.0.7:
+    resolution: {integrity: sha512-IP3dEjxGUXnU9Ev6znBzPBvM6x2nIebP4NUW1Z5g1XEi37FgEzSPmQExkdVOdtf2B6oeC8r4pzIvBobLx7ewMw==}
 
   prettier-plugin-ember-template-tag@2.1.2:
     resolution: {integrity: sha512-SZqbv8qfqJ7AnAaNhyeHOzsq1kvlkHdVrCAZDVBjUeWuW8xF2AK7LfKRkn9MPEUsbEO7BSkLsjkb5++eoWjtGw==}
     version: 2.1.2
     engines: {node: 18.* || >= 20}
     peerDependencies:
-      prettier: github:jurgenwerk/prettier#glimmer-embed-style-wip
+      prettier: '>= 3.0.0'
 
   prettier@https://codeload.github.com/jurgenwerk/prettier/tar.gz/4ec1dd2669715bb9e4487366f330f7686fb5d159:
     resolution: {tarball: https://codeload.github.com/jurgenwerk/prettier/tar.gz/4ec1dd2669715bb9e4487366f330f7686fb5d159}
@@ -9560,7 +9556,7 @@ snapshots:
     transitivePeerDependencies:
       - babel-plugin-macros
 
-  '@adonisjs/auth@9.5.1(p5grlqoizembbn45vzffxszpdq)':
+  '@adonisjs/auth@9.5.1(6b2bd7ec29f2e3c48da0991ceb6f39c3)':
     dependencies:
       '@adonisjs/core': 6.19.3(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@vinejs/vine@4.2.0)(edge.js@6.4.0)
       '@adonisjs/presets': 2.6.4(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@adonisjs/core@6.19.3(@adonisjs/assembler@7.8.2(typescript@5.9.3))(@vinejs/vine@4.2.0)(edge.js@6.4.0))
@@ -9792,7 +9788,7 @@ snapshots:
 
   '@adonisjs/prettier-config@1.4.5':
     dependencies:
-      prettier-plugin-edgejs: 1.0.6
+      prettier-plugin-edgejs: 1.0.7
     transitivePeerDependencies:
       - '@angular/core'
       - supports-color
@@ -11208,22 +11204,22 @@ snapshots:
 
   '@borewit/text-codec@0.2.1': {}
 
-  '@chevrotain/cst-dts-gen@11.1.0':
+  '@chevrotain/cst-dts-gen@11.2.0':
     dependencies:
-      '@chevrotain/gast': 11.1.0
-      '@chevrotain/types': 11.1.0
-      lodash-es: 4.17.21
+      '@chevrotain/gast': 11.2.0
+      '@chevrotain/types': 11.2.0
+      lodash-es: 4.17.23
 
-  '@chevrotain/gast@11.1.0':
+  '@chevrotain/gast@11.2.0':
     dependencies:
-      '@chevrotain/types': 11.1.0
-      lodash-es: 4.17.21
+      '@chevrotain/types': 11.2.0
+      lodash-es: 4.17.23
 
-  '@chevrotain/regexp-to-ast@11.1.0': {}
+  '@chevrotain/regexp-to-ast@11.2.0': {}
 
-  '@chevrotain/types@11.1.0': {}
+  '@chevrotain/types@11.2.0': {}
 
-  '@chevrotain/utils@11.1.0': {}
+  '@chevrotain/utils@11.2.0': {}
 
   '@cnakazawa/watch@1.0.4':
     dependencies:
@@ -14104,14 +14100,14 @@ snapshots:
 
   check-disk-space@3.4.0: {}
 
-  chevrotain@11.1.0:
+  chevrotain@11.2.0:
     dependencies:
-      '@chevrotain/cst-dts-gen': 11.1.0
-      '@chevrotain/gast': 11.1.0
-      '@chevrotain/regexp-to-ast': 11.1.0
-      '@chevrotain/types': 11.1.0
-      '@chevrotain/utils': 11.1.0
-      lodash-es: 4.17.21
+      '@chevrotain/cst-dts-gen': 11.2.0
+      '@chevrotain/gast': 11.2.0
+      '@chevrotain/regexp-to-ast': 11.2.0
+      '@chevrotain/types': 11.2.0
+      '@chevrotain/utils': 11.2.0
+      lodash-es: 4.17.23
 
   chokidar@4.0.3:
     dependencies:
@@ -14622,9 +14618,9 @@ snapshots:
       property-information: 7.1.0
       stringify-attributes: 4.0.0
 
-  edgejs-parser@0.2.18:
+  edgejs-parser@0.2.19:
     dependencies:
-      chevrotain: 11.1.0
+      chevrotain: 11.2.0
 
   editions@1.3.4: {}
 
@@ -17325,7 +17321,7 @@ snapshots:
     dependencies:
       p-locate: 6.0.0
 
-  lodash-es@4.17.21: {}
+  lodash-es@4.17.23: {}
 
   lodash._baseflatten@3.1.4:
     dependencies:
@@ -18235,21 +18231,14 @@ snapshots:
 
   prelude-ls@1.2.1: {}
 
-  prettier-edgejs@0.2.36:
-    dependencies:
-      prettier-plugin-edgejs: 1.0.6
-    transitivePeerDependencies:
-      - '@angular/core'
-      - supports-color
-
   prettier-linter-helpers@1.0.1:
     dependencies:
       fast-diff: 1.3.0
 
-  prettier-plugin-edgejs@1.0.6:
+  prettier-plugin-edgejs@1.0.7:
     dependencies:
       '@adobe/css-tools': 4.4.4
-      edgejs-parser: 0.2.18
+      edgejs-parser: 0.2.19
       prettier: https://codeload.github.com/jurgenwerk/prettier/tar.gz/4ec1dd2669715bb9e4487366f330f7686fb5d159
       uglify-js: 3.19.3
     transitivePeerDependencies:


### PR DESCRIPTION
The Lint job hasn't completed since the January dep upgrades — it hangs until the 6-hour runner timeout (that's what the old "cancelled after 6h" runs were). Two stacked root causes:

## 1. `prettier-edgejs` is now an empty deprecation stub

`prettier-edgejs@^0.2.34` resolves to 0.2.36, which ships **no code** — just a README saying "renamed to `prettier-plugin-edgejs`". So prettier throws (`Cannot find module .../prettier-edgejs/dist/main.js`) the moment it loads `.prettierrc.cjs`. Fixed by depending on `prettier-plugin-edgejs@^1.0.7` and updating both plugin references in `.prettierrc.cjs`. Its formatter reflows the four `.edge` views slightly — included so `git diff --exit-code` passes.

## 2. eslint-plugin-prettier deadlocks against the prettier fork

`eslint-plugin-prettier` runs prettier inside a synckit worker thread whose first line is `import prettier from 'prettier'`. The workspace pins prettier to a **source tarball** (`github:jurgenwerk/prettier#glimmer-embed-style-wip`, reports as `3.5.0-dev`) — and the repo source, unlike the published npm build, has **no default export**. The worker crashes at import; synckit's default timeout is *infinite*; the main thread blocks on `Atomics.wait` forever with zero CPU. (Diagnosed by running with `SYNCKIT_TIMEOUT=5000`, which surfaces the real error instead of hanging.)

Fixed by disabling the `prettier/prettier` rule in `api/eslint.config.js`. This isn't a workaround-with-a-loss: this same CI job already enforces formatting via `pnpm lint:fix` + `git diff --exit-code`, so running prettier a second time per-file inside eslint was pure double work even when it functioned. The prettier fork stays in place for actual formatting (which works fine via the CLI).

**Result: full api lint goes from a 6-hour hang to ~1.6s; root `pnpm lint:fix` takes ~4s.**

Also in this PR:

- `STRIPE_SUB_CACHE` → `StripeSubCache` — the moment lint actually ran, it flagged the naming-convention violation (the name came from Theo's guide verbatim)
- `timeout-minutes: 10` on the Lint job, so if anything like this recurs it fails in minutes instead of burning a 6-hour runner

Verification: `pnpm exec eslint .` in api = 1.6s clean; root `pnpm lint:fix` = 3.9s and reaches a fixpoint (re-running produces no changes); api typecheck clean; unit tests pass. Note `pnpm --filter '*' lint` never linted `web-client` — its script is deliberately named `_lint`, so this hang was always the api package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
